### PR TITLE
Maintain support for dbt 0.17.2

### DIFF
--- a/models/stg_hubspot__contact.sql
+++ b/models/stg_hubspot__contact.sql
@@ -10,7 +10,7 @@ with base as (
 
     select
         id as contact_id,
-        {{ remove_prefix_from_columns(columns=columns, exclude=['id']) }}
+        {{ remove_prefix_from_columns(columns=columns, exclude=['id','PROPERTY_CONTACT_ID']) }}
     from base
 
 )

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: fishtown-analytics/dbt_utils
-    version: [">=0.4.0"]
+    version: 0.5.1


### PR DESCRIPTION
This PR is simply to maintain support for dbt `0.17.2`, which is also the version of dbt running in the new Fivetran dbt transformations. The `>=` reference with `db_utils` meant that dbt was pulling down the version that only works with `0.18.0`.

Additionally... I had to exclude `PROPERTY_CONTACT_ID` from removing prefixes, as it interfered with `ID as CONTACT_ID`. I assumed this was the right direction to make this work.