### PR TITLE
add enabled flag to some contacts models

### DIFF
--- a/models/stg_hubspot__contact.sql
+++ b/models/stg_hubspot__contact.sql
@@ -1,3 +1,4 @@
+{{ config(enabled=fivetran_utils.enabled_vars(['hubspot_marketing_enabled'])) }}
 {%- set columns = adapter.get_columns_in_relation(ref('stg_hubspot__contact_adapter')) -%}
 
 with base as (

--- a/models/stg_hubspot__contact_adapter.sql
+++ b/models/stg_hubspot__contact_adapter.sql
@@ -1,2 +1,4 @@
+{{ config(enabled=fivetran_utils.enabled_vars(['hubspot_marketing_enabled'])) }}
+
 select *
 from {{ var('contact') }}

--- a/models/stg_hubspot__contact_property_history.sql
+++ b/models/stg_hubspot__contact_property_history.sql
@@ -1,3 +1,5 @@
+{{ config(enabled=fivetran_utils.enabled_vars(['hubspot_marketing_enabled'])) }}
+
 with base as (
 
     select *


### PR DESCRIPTION
This PR solves that the models stg_hubspot__contact, stg_hubspot__contact_adapter, stg_hubspot__contact_property_history are created even though you put hubspot_marketing_enabled to false.