### PR TITLE
pass through custom data columns

### DIFF
--- a/macros/add_pass_through_columns.sql
+++ b/macros/add_pass_through_columns.sql
@@ -1,0 +1,13 @@
+{% macro add_pass_through_columns(base_columns, pass_through_var) %}
+
+  {% if pass_through_var %}
+
+    {% for column in pass_through_var %}
+
+      {% do base_columns.append({ "name": column.name, "datatype": column.datatype, "alias": column.alias }) %}
+
+    {% endfor %}
+
+  {% endif %}
+
+{% endmacro %}

--- a/macros/get_deal_columns.sql
+++ b/macros/get_deal_columns.sql
@@ -9,7 +9,7 @@
     {"name": "owner_id", "datatype": dbt_utils.type_int()},
     {"name": "portal_id", "datatype": dbt_utils.type_int()},
     {"name": "property_amount", "datatype": dbt_utils.type_float()},
-    {"name": "property_amount_in_home_currency", "datatype": dbt_utils.type_float()},    
+    {"name": "property_amount_in_home_currency", "datatype": dbt_utils.type_float()},
     {"name": "property_closed_lost_reason", "datatype": dbt_utils.type_string()},
     {"name": "property_closedate", "datatype": dbt_utils.type_timestamp()},
     {"name": "property_createdate", "datatype": dbt_utils.type_timestamp()},
@@ -23,7 +23,7 @@
     {"name": "property_hs_closed_amount", "datatype": dbt_utils.type_float()},
     {"name": "property_hs_closed_amount_in_home_currency", "datatype": dbt_utils.type_float()},
     {"name": "property_hs_created_by_user_id", "datatype": dbt_utils.type_float()},
-    {"name": "property_hs_createdate", "datatype": dbt_utils.type_timestamp()},  
+    {"name": "property_hs_createdate", "datatype": dbt_utils.type_timestamp()},
     {"name": "property_hs_date_entered_closedlost", "datatype": dbt_utils.type_timestamp()},
     {"name": "property_hs_date_entered_presentationscheduled", "datatype": dbt_utils.type_timestamp()},
     {"name": "property_hs_date_entered_qualifiedtobuy", "datatype": dbt_utils.type_timestamp()},
@@ -46,8 +46,11 @@
     {"name": "property_notes_last_updated", "datatype": dbt_utils.type_timestamp()},
     {"name": "property_notes_next_activity_date", "datatype": dbt_utils.type_timestamp()},
     {"name": "property_num_contacted_notes", "datatype": dbt_utils.type_float()},
-    {"name": "property_num_notes", "datatype": dbt_utils.type_float()},
+    {"name": "property_num_notes", "datatype": dbt_utils.type_float()}
 ] %}
+
+-- add pass through columns from project var
+{{ add_pass_through_columns(columns, var('deal_pass_through_columns')) }}
 
 {{ return(columns) }}
 

--- a/models/stg_hubspot__deal.sql
+++ b/models/stg_hubspot__deal.sql
@@ -1,7 +1,5 @@
 {{ config(enabled=fivetran_utils.enabled_vars(['hubspot_sales_enabled','hubspot_deal_enabled'])) }}
 
-{%- set columns = adapter.get_columns_in_relation(ref('stg_hubspot__deal_tmp')) -%}
-
 with base as (
 
     select *
@@ -11,7 +9,14 @@ with base as (
 ), fields as (
 
     select
-        {{ fivetran_utils.remove_prefix_from_columns(columns=columns, prefix='property_') }}
+
+        {{
+            fivetran_utils.fill_staging_columns(
+                source_columns=adapter.get_columns_in_relation(ref('stg_hubspot__deal_tmp')),
+                staging_columns=get_deal_columns()
+            )
+        }}
+
     from base
 
 )


### PR DESCRIPTION
Rather than simply pass along all source columns sans `property_`, why not set a default set of core columns and allow the user to add custom data columns using variable maps. Some tables have 100+ fields, with many that have very little value. `hubspot.deal` is particularly awful; for example, what can I do with `property_hs_date_exited_1215013`...

This behavior also ensures that all renaming and casting is captured in the staging and allows for simpler, downstream models

I've mocked up what this could look like for HubSpot deals but this could also be used for the `company`, `contact`, and soon-to-come `ticket` models. 

Sample var for deal columns:

```
dbt_project.yml

...

vars:

  deal_pass_through_columns:
  
        - name: "property_sales_development_representative"
          alias: "sales_development_representative_owner_id"
  
        - name: "property_energy_consultant"
          alias: "energy_consultant_owner_id"

```