### PR TITLE
Correct where clause in staging models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# dbt_hubspot_source v0.5.6
+## Bug Fixes
+- The below staging tables contain a `where` clause to filter out soft deletes. However, this where clause was conducted in the first CTE of the staging model before the `fill_staging_columns` macro. Therefore, if the field doesn't exist, the dbt run would fail. These updates have moved the CTE to the final one to avoid this error. ([#68](https://github.com/fivetran/dbt_hubspot_source/pull/68))
+  - `stg_hubspot__company`, `stg_hubspot__contact`, `stg_hubspot__contact_list`, `stg_hubspot__deal`, `stg_hubspot__deal_pipeline`, `stg_hubspot__deal_pipeline_stage`, `stg_hubspot__ticket`, and `stg_hubspot__contact_list`.
+
+## Contributors
+- [@sambradbury](https://github.com/sambradbury) ([#67](https://github.com/fivetran/dbt_hubspot_source/pull/67))
 # dbt_hubspot_source v0.5.5
 ## Fixes
 - Adds missing `stg_hubspot__deal_contact` model. ([#64](https://github.com/fivetran/dbt_hubspot_source/pull/64))

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'hubspot_source'
-version: '0.5.5'
+version: '0.5.6'
 config-version: 2
 require-dbt-version: [">=1.0.0", "<2.0.0"]
 

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,6 +1,6 @@
 
 name: 'hubspot_source_integration_tests'
-version: '0.5.5'
+version: '0.5.6'
 profile: 'integration_tests'
 config-version: 2
 

--- a/models/stg_hubspot__company.sql
+++ b/models/stg_hubspot__company.sql
@@ -4,7 +4,6 @@ with base as (
 
     select *
     from {{ ref('stg_hubspot__company_tmp') }}
-    where not coalesce(is_deleted, false) 
 
 ), macro as (
 
@@ -61,3 +60,4 @@ with base as (
 
 select *
 from fields
+where not coalesce(is_deleted, false) 

--- a/models/stg_hubspot__contact.sql
+++ b/models/stg_hubspot__contact.sql
@@ -4,7 +4,6 @@ with base as (
 
     select *
     from {{ ref('stg_hubspot__contact_tmp') }}
-    where not coalesce(_fivetran_deleted, false) 
 
 ), macro as (
 
@@ -56,3 +55,4 @@ with base as (
 
 select *
 from fields
+where not coalesce(_fivetran_deleted, false) 

--- a/models/stg_hubspot__contact_list.sql
+++ b/models/stg_hubspot__contact_list.sql
@@ -4,7 +4,6 @@ with base as (
 
     select *
     from {{ ref('stg_hubspot__contact_list_tmp') }}
-    where not coalesce(_fivetran_deleted, false) 
 
 ), macro as (
 
@@ -40,3 +39,4 @@ with base as (
 
 select *
 from fields
+where not coalesce(_fivetran_deleted, false) 

--- a/models/stg_hubspot__contact_list_member.sql
+++ b/models/stg_hubspot__contact_list_member.sql
@@ -3,8 +3,7 @@
 with base as (
 
     select *
-    from {{ ref('stg_hubspot__contact_list_member_tmp') }}
-    where not coalesce(_fivetran_deleted, false) 
+    from {{ ref('stg_hubspot__contact_list_member_tmp') }} 
 
 ), macro as (
 
@@ -31,3 +30,4 @@ with base as (
 
 select *
 from fields
+where not coalesce(_fivetran_deleted, false)

--- a/models/stg_hubspot__deal.sql
+++ b/models/stg_hubspot__deal.sql
@@ -4,7 +4,6 @@ with base as (
 
     select *
     from {{ ref('stg_hubspot__deal_tmp') }}
-    where not coalesce(is_deleted, false)
 
 ), macro as (
 
@@ -58,3 +57,4 @@ with base as (
 
 select *
 from fields
+where not coalesce(is_deleted, false)

--- a/models/stg_hubspot__deal_pipeline.sql
+++ b/models/stg_hubspot__deal_pipeline.sql
@@ -4,7 +4,6 @@ with base as (
 
     select *
     from {{ ref('stg_hubspot__deal_pipeline_tmp') }}
-    where not coalesce(_fivetran_deleted, false) 
 
 ), macro as (
 
@@ -32,5 +31,5 @@ with base as (
 
 select *
 from fields
-
+where not coalesce(_fivetran_deleted, false) 
 

--- a/models/stg_hubspot__deal_pipeline_stage.sql
+++ b/models/stg_hubspot__deal_pipeline_stage.sql
@@ -4,7 +4,6 @@ with base as (
 
     select *
     from {{ ref('stg_hubspot__deal_pipeline_stage_tmp') }}
-    where not coalesce(_fivetran_deleted, false) 
 
 ), macro as (
 
@@ -35,3 +34,4 @@ with base as (
 
 select *
 from fields
+where not coalesce(_fivetran_deleted, false) 

--- a/models/stg_hubspot__ticket.sql
+++ b/models/stg_hubspot__ticket.sql
@@ -4,7 +4,6 @@ with base as (
 
     select *
     from {{ ref('stg_hubspot__ticket_tmp') }}
-    where not coalesce(is_deleted, false) 
 
 ), macro as (
 
@@ -59,3 +58,4 @@ with base as (
 
 select *
 from fields
+where not coalesce(is_deleted, false) 


### PR DESCRIPTION
**Are you a current Fivetran customer?** 
<!--- Please tell us your name, title and company -->
Fivetran created PR

**What change(s) does this PR introduce?** 
<!--- Describe what changes your PR introduces to the package and how to leverage this new feature. -->
Adjusts the where clause in certain staging models that filter out soft deletes to perform the filter in the final cte instead of the first. This way, if that field does not exist, it can leverage the `fill_staging_columns` macro to pass the null record through.

**Did you update the CHANGELOG?** 
<!--- Please update the new package version’s CHANGELOG entry detailing the changes included in this PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes

**Does this PR introduce a breaking change?**
<!--- Does this PR introduce changes that will cause current package users' jobs to fail or require a `--full-refresh`? -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes (please provide breaking change details below.)
- [X] No  (please provide an explanation as to how the change is non-breaking below.)

This will be a patch release as we are just moving the where clause to a different part of the staging models.

**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)** 
<!--- The dbt_project.yml and the integration_tests/dbt_project.yml files contain the version number. Be sure to upgrade it accordingly -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes

**Is this PR in response to a previously created Bug or Feature Request**
<!--- If an Issue was created it is helpful to track the progress by linking it in the PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [X] Yes, Issue #66 
- [ ] No 

**How did you test the PR changes?** 
<!--- Proof of testing is required in order for the PR to be approved. -->
<!--- To check a box, remove the space and insert an x in the box (eg. [x] CircleCi). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [X] CircleCi <!--- CircleCi testing is only applicable to Fivetran employees. --> 
- [X] Local (please provide additional testing details below)

**Select which warehouse(s) were used to test the PR**
<!--- To check a warehouse remove the space and insert an x in the box (eg. [x] Bigquery). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [X] BigQuery
- [X] Redshift
- [X] Snowflake
- [X] Postgres
- [ ] Databricks
- [ ] Other (provide details below)

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
☸️ 

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.
