### PR TITLE
adding documentation for aliased columns

### DIFF
--- a/models/stg_hubspot__company_property_history.sql
+++ b/models/stg_hubspot__company_property_history.sql
@@ -24,7 +24,7 @@ with base as (
         name as field_name,
         source as change_source,
         source_id as change_source_id,
-        change_timestamp, -- source field name = timestamp ; alias declared in model's macros
+        change_timestamp, -- source field name = timestamp ; alias declared in macros/get_company_property_history_columns.sql
         value as new_value
     from macro
     

--- a/models/stg_hubspot__company_property_history.sql
+++ b/models/stg_hubspot__company_property_history.sql
@@ -24,7 +24,7 @@ with base as (
         name as field_name,
         source as change_source,
         source_id as change_source_id,
-        change_timestamp,
+        change_timestamp, -- source field name = timestamp ; alias declared in model's macros
         value as new_value
     from macro
     

--- a/models/stg_hubspot__contact_property_history.sql
+++ b/models/stg_hubspot__contact_property_history.sql
@@ -24,7 +24,7 @@ with base as (
         name as field_name,
         source as change_source,
         source_id as change_source_id,
-        change_timestamp,
+        change_timestamp, -- source field name = timestamp ; alias declared in model's macros
         value as new_value
     from macro
     

--- a/models/stg_hubspot__contact_property_history.sql
+++ b/models/stg_hubspot__contact_property_history.sql
@@ -24,7 +24,7 @@ with base as (
         name as field_name,
         source as change_source,
         source_id as change_source_id,
-        change_timestamp, -- source field name = timestamp ; alias declared in model's macros
+        change_timestamp, -- source field name = timestamp ; alias declared in macros/get_contact_property_history_columns.sql
         value as new_value
     from macro
     

--- a/models/stg_hubspot__deal_property_history.sql
+++ b/models/stg_hubspot__deal_property_history.sql
@@ -24,7 +24,7 @@ with base as (
         name as field_name,
         source as change_source,
         source_id as change_source_id,
-        change_timestamp,
+        change_timestamp, -- source field name = timestamp ; alias declared in model's macros
         value as new_value
     from macro
     

--- a/models/stg_hubspot__deal_property_history.sql
+++ b/models/stg_hubspot__deal_property_history.sql
@@ -24,7 +24,7 @@ with base as (
         name as field_name,
         source as change_source,
         source_id as change_source_id,
-        change_timestamp, -- source field name = timestamp ; alias declared in model's macros
+        change_timestamp, -- source field name = timestamp ; alias declared in macros/get_deal_property_history_columns.sql
         value as new_value
     from macro
     

--- a/models/stg_hubspot__email_event_dropped.sql
+++ b/models/stg_hubspot__email_event_dropped.sql
@@ -24,7 +24,7 @@ with base as (
         cc as cc_emails,
         drop_message,
         drop_reason,
-        from_email,
+        from_email, -- source field name = from ; alias declared in model's macros
         id as event_id,
         reply_to as reply_to_email,
         subject as email_subject

--- a/models/stg_hubspot__email_event_dropped.sql
+++ b/models/stg_hubspot__email_event_dropped.sql
@@ -24,7 +24,7 @@ with base as (
         cc as cc_emails,
         drop_message,
         drop_reason,
-        from_email, -- source field name = from ; alias declared in model's macros
+        from_email, -- source field name = from ; alias declared in macros/get_email_event_dropped_columns.sql
         id as event_id,
         reply_to as reply_to_email,
         subject as email_subject

--- a/models/stg_hubspot__email_event_sent.sql
+++ b/models/stg_hubspot__email_event_sent.sql
@@ -22,7 +22,7 @@ with base as (
         _fivetran_synced,
         bcc as bcc_emails,
         cc as cc_emails,
-        from_email, -- source field name = from ; alias declared in model's macros
+        from_email, -- source field name = from ; alias declared in macros/get_email_event_sent_columns.sql
         id as event_id,
         reply_to as reply_to_email,
         subject as email_subject

--- a/models/stg_hubspot__email_event_sent.sql
+++ b/models/stg_hubspot__email_event_sent.sql
@@ -22,7 +22,7 @@ with base as (
         _fivetran_synced,
         bcc as bcc_emails,
         cc as cc_emails,
-        from_email,
+        from_email, -- source field name = from ; alias declared in model's macros
         id as event_id,
         reply_to as reply_to_email,
         subject as email_subject

--- a/models/stg_hubspot__engagement.sql
+++ b/models/stg_hubspot__engagement.sql
@@ -27,7 +27,7 @@ with base as (
         last_updated as last_updated_timestamp,
         owner_id,
         portal_id,
-        occurred_timestamp, -- source field name = timestamp ; alias declared in model's macros
+        occurred_timestamp, -- source field name = timestamp ; alias declared in macros/get_engagement_columns.sql
         engagement_type
     from macro
     

--- a/models/stg_hubspot__engagement.sql
+++ b/models/stg_hubspot__engagement.sql
@@ -27,7 +27,7 @@ with base as (
         last_updated as last_updated_timestamp,
         owner_id,
         portal_id,
-        occurred_timestamp,
+        occurred_timestamp, -- source field name = timestamp ; alias declared in model's macros
         engagement_type
     from macro
     


### PR DESCRIPTION
Just adding some comments for columns of models that are aliased in their macros as opposed to in the model themselves for future reference. 