### PR TITLE
parametrize existing source freshness tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,22 @@ vars:
     hubspot_<default_source_table_name>_identifier: your_table_name 
 ```
 
+### Change freshness settings
+
+In order to change the settings of freshness tests on all source tables, you can set the default variables:
+```yml
+vars:
+    hubspot_freshness_warn: number_of_hours 
+    hubspot_freshness_error: number_of_hours 
+```
+
+You can as well set specific configurations by source tables:
+```yml
+vars:
+    hubspot_freshness_warn_<specific_source_table_name>: number_of_hours 
+    hubspot_freshness_error_<specific_source_table_name>: number_of_hours 
+```
+
 ## (Optional) Step 6: Orchestrate your models with Fivetran Transformations for dbt Core™
 
 Fivetran offers the ability for you to orchestrate your dbt project through [Fivetran Transformations for dbt Core™](https://fivetran.com/docs/transformations/dbt). Learn how to set up your project for orchestration through Fivetran in our [Transformations for dbt Core setup guides](https://fivetran.com/docs/transformations/dbt#setupguide).

--- a/models/src_hubspot.yml
+++ b/models/src_hubspot.yml
@@ -187,8 +187,14 @@ sources:
       - name: contact
         identifier: "{{ var('hubspot_contact_identifier', 'contact')}}"
         freshness:
-          warn_after: {count: 84, period: hour}
-          error_after: {count: 168, period: hour}
+          warn_after: {
+            count: "{{ var('hubspot_freshness_warn_contact', var('hubspot_freshness_warn',84)) }}",
+            period: hour
+          }
+          error_after: {
+            count: "{{ var('hubspot_freshness_error_contact', var('hubspot_freshness_error',168)) }}",
+            period: hour
+          }
         description: Each record represents a contact in Hubspot.
         config:
           enabled: "{{ var('hubspot_marketing_enabled', true) and var('hubspot_contact_enabled', true) }}"
@@ -322,8 +328,14 @@ sources:
       - name: contact_property_history
         identifier: "{{ var('hubspot_contact_property_history_identifier', 'contact_property_history')}}"
         freshness:
-          warn_after: {count: 84, period: hour}
-          error_after: {count: 168, period: hour}
+          warn_after: {
+            count: "{{ var('hubspot_freshness_warn_contact_property_history', var('hubspot_freshness_warn',84)) }}",
+            period: hour
+          }
+          error_after: {
+            count: "{{ var('hubspot_freshness_error_contact_property_history', var('hubspot_freshness_error',168)) }}",
+            period: hour
+          }
         description: Each record represents a change to contact record in Hubspot.
         config:
           enabled: "{{ var('hubspot_marketing_enabled', true) and var('hubspot_contact_property_enabled', true) }}"
@@ -569,8 +581,14 @@ sources:
       - name: email_event
         identifier: "{{ var('hubspot_email_event_identifier', 'email_event')}}"
         freshness:
-          warn_after: {count: 84, period: hour}
-          error_after: {count: 168, period: hour}
+          warn_after: {
+            count: "{{ var('hubspot_freshness_warn_email_event', var('hubspot_freshness_warn',84)) }}",
+            period: hour
+          }
+          error_after: {
+            count: "{{ var('hubspot_freshness_error_email_event', var('hubspot_freshness_error',168)) }}",
+            period: hour
+          }
         description: Each record represents an email event in Hubspot.
         config:
           enabled: "{{ var('hubspot_marketing_enabled', true) and var('hubspot_email_event_enabled', true) }}"


### PR DESCRIPTION
Pull Request
**Are you a current Fivetran customer?** 
yes yousign
**What change(s) does this PR introduce?** 

This PR allows the parametrization of freshness tests done in the hubspot source package. Indeed in the current version the tests are done for 84/168 hours (resp. warning, error). I needed a smaller timelapse for my tests. 

I propose to use a variable to set the number of hour needed. 
I was thinking at first on a unique number of hour for all tables, but I thought that maybe some tables do not need the same freshness (ex. contact is updated regularly but some tables might be less updated), therefore I added 2 couples of variables: 

Warnings: `hubspot_freshness_warn_NAME_OF_THE_TABLE` and `hubspot_freshness_warn`
Errors: `hubspot_freshness_error_NAME_OF_THE_TABLE` and `hubspot_freshness_error`

With this structure we can set a default for all tables and if a table needs some special freshness test it is as well possible, I kept the 84/168 value for absolute default. 
This give a not very pretty syntax of `var(xxx, var())` but I do not see how to do it more gracefully. 

Please give me your opinion :) 
I did for now the change only on tables where freshness was implemented but I'd love to have it on others as well, (I can add later, after getting your review).

 



**Did you update the CHANGELOG?** 
- [ ] Yes

**Does this PR introduce a breaking change?**
<!--- Does this PR introduce changes that will cause current package users' jobs to fail or require a `--full-refresh`? -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes (please provide breaking change details below.)
- [x] No, because I kept the absolute default of 84/168

**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)** 
<!--- The dbt_project.yml and the integration_tests/dbt_project.yml files contain the version number. Be sure to upgrade it accordingly -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes

**Is this PR in response to a previously created Bug or Feature Request**
<!--- If an Issue was created it is helpful to track the progress by linking it in the PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes, Issue/Feature [link bug/feature number here]
- [x] No 

**How did you test the PR changes?** 
<!--- Proof of testing is required in order for the PR to be approved. -->
<!--- To check a box, remove the space and insert an x in the box (eg. [x] CircleCi). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] CircleCi <!--- CircleCi testing is only applicable to Fivetran employees. --> 
- [x] Local tested locally on my dbt project

**Select which warehouse(s) were used to test the PR**
<!--- To check a warehouse remove the space and insert an x in the box (eg. [x] Bigquery). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] BigQuery
- [ ] Redshift
- [x] Snowflake
- [ ] Postgres
- [ ] Databricks
- [ ] Other (provide details below)

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
🧝‍♂️

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.
