### PR TITLE
Restore Deleted Deal Pipelines and Deal Pipeline Stages

### DIFF
--- a/models/stg_hubspot__deal.yml
+++ b/models/stg_hubspot__deal.yml
@@ -24,7 +24,9 @@ models:
         description: Used to determine the order in which the stages appear when viewed in HubSpot.
 
       - name: is_active
-        description: Whether the pipeline stage is currently in use.
+        description: >
+          Whether the pipeline stage is currently in use. Since HubSpot hard deletes pipeline stages, this column
+          returns the inverse of _fivetran_deleted.
 
       - name: is_closed_won
         description: Whether the stage represents a Closed Won deal.
@@ -54,7 +56,9 @@ models:
         description: Used to determine the order in which the pipelines appear when viewed in HubSpot
 
       - name: is_active
-        description: Whether the stage is currently in use.
+        description: >
+          Whether the pipeline stage is currently in use. Since HubSpot hard deletes pipelines, this column
+          returns the inverse of _fivetran_deleted.
 
       - name: pipeline_label
         description: The human-readable label for the pipeline. The label is used when showing the pipeline in HubSpot.

--- a/models/stg_hubspot__deal_pipeline.sql
+++ b/models/stg_hubspot__deal_pipeline.sql
@@ -21,7 +21,7 @@ with base as (
     select
         _fivetran_deleted,
         _fivetran_synced,
-        active as is_active,
+        not coalesce(_fivetran_deleted, false) as is_active,
         display_order,
         label as pipeline_label,
         cast(pipeline_id as {{ dbt.type_string() }}) as deal_pipeline_id
@@ -31,5 +31,3 @@ with base as (
 
 select *
 from fields
-where not coalesce(_fivetran_deleted, false) 
-

--- a/models/stg_hubspot__deal_pipeline_stage.sql
+++ b/models/stg_hubspot__deal_pipeline_stage.sql
@@ -21,7 +21,7 @@ with base as (
     select
         _fivetran_deleted,
         _fivetran_synced,
-        active as is_active,
+        not coalesce(_fivetran_deleted, false) as is_active, as is_active,
         closed_won as is_closed_won,
         display_order,
         label as pipeline_stage_label,
@@ -34,4 +34,3 @@ with base as (
 
 select *
 from fields
-where not coalesce(_fivetran_deleted, false) 


### PR DESCRIPTION
**Are you a current Fivetran customer?** 
Yes, Dandelion Energy

**What change(s) does this PR introduce?** 
Restores deleted deal pipelines and deal pipeline stages to `stg_hubspot__deal_pipeline` and `stg_hubspot__deal_pipeline_stage`, respectively. Repurposes the `is_active` boolean column to return the inverse of `_fivetran_deleted` given HubSpot hard deletes pipelines and `is_active` is always true (in our instance at least). 
**Did you update the CHANGELOG?** 
- [ ] Yes

**Does this PR introduce a breaking change?**
- [ ] Yes (please provide breaking change details below.)
- [x] No  (please provide an explanation as to how the change is non-breaking below.)

This should not cause any of the uniqueness or null tests to fail for either object unless users somehow delete and re-create pipelines or stages with the same enum/ID (I don't believe this is possible anymore)

**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)** 
- [ ] Yes

**Is this PR in response to a previously created Bug or Feature Request**
- [x] Yes, Issue/Feature [https://github.com/fivetran/dbt_hubspot_source/issues/93]
- [ ] No 

**How did you test the PR changes?** 
- [ ] Buildkite <!--- Buildkite testing is only applicable to Fivetran employees. --> 
- [x] Local (please provide additional testing details below)

**Select which warehouse(s) were used to test the PR**
- [x] BigQuery
- [ ] Redshift
- [ ] Snowflake
- [ ] Postgres
- [ ] Databricks
- [ ] Other (provide details below)

**Provide an emoji that best describes your current mood**
🕵️‍♂️

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.
