### PR TITLE
Loop twice

### DIFF
--- a/macros/remove_duplicate_and_prefix_from_columns.sql
+++ b/macros/remove_duplicate_and_prefix_from_columns.sql
@@ -1,5 +1,6 @@
 {% macro remove_duplicate_and_prefix_from_columns(columns, prefix='', exclude=[]) %}
         
+        {# Loop once to find duplicates #}
         {%- set duplicate_exclude = [] -%}
         {% for col in columns if col.name not in exclude %}
         {%- for dupe in columns if col.name[prefix|length:]|lower == dupe.name|lower -%}
@@ -7,6 +8,10 @@
         {%- do duplicate_exclude.append(dupe.name) -%}
         , coalesce({{ col.name }}, {{dupe.name}}) as {{ col.name[prefix|length:] }}
         {%- endfor %}
+        {% endfor %}
+
+        {# Loop again to find non-duplicates #}
+        {% for col in columns if col.name not in exclude %}
         {%- if col.name|lower not in duplicate_exclude|lower -%}
         {% if col.name[:prefix|length]|lower == prefix %}
         , {{ col.name }} as {{ col.name[prefix|length:] }}


### PR DESCRIPTION
Else you end up with `MEETING_OUTCOME` etc. in there twice, since the first iteration doesn't know to exclude it yet as a dupe.

If I put logging in your original code:

```
 {%- do duplicate_exclude.append(dupe.name) -%}
        , coalesce({{ col.name }}, {{dupe.name}}) as {{ col.name[prefix|length:] }}
        {%- endfor %}
        {{print(duplicate_exclude)}}
        {{print(col.name)}}
        {%- if col.name|lower not in duplicate_exclude|lower -%}
        {% if col.name[:prefix|length]|lower == prefix %}
```

`MEETING_OUTCOME` isn't in your `duplicate_exclude` yet and thus is added twice.

```
[]
BODY
[]
START_TIME
[]
END_TIME
[]
TITLE
[]
EXTERNAL_URL
[]
SOURCE
[]
CREATED_FROM_LINK_ID
[]
SOURCE_ID
[]
WEB_CONFERENCE_MEETING_ID
[]
MEETING_OUTCOME
[]
PRE_MEETING_PROSPECT_REMINDERS
[]
I_CAL_UID
[]
INTERNAL_MEETING_NOTES
[]
LOCATION
[]
ATTENDEE_OWNER_IDS
[]
MEETING_CHANGE_ID
[]
CALENDAR_EVENT_HASH
[]
PROPERTY_HS_ENGAGEMENT_SOURCE_ID
[]
PROPERTY_HS_LASTMODIFIEDDATE
['PROPERTY_HS_MEETING_OUTCOME', 'MEETING_OUTCOME']
PROPERTY_HS_OUTCOME_COMPLETED_COUNT
['PROPERTY_HS_MEETING_OUTCOME', 'MEETING_OUTCOME']
PROPERTY_HS_OUTCOME_SCHEDULED_COUNT
['PROPERTY_HS_MEETING_OUTCOME', 'MEETING_OUTCOME']
PROPERTY_HS_MEETING_START_TIME
['PROPERTY_HS_MEETING_OUTCOME', 'MEETING_OUTCOME']
PROPERTY_HS_OUTCOME_NO_SHOW_COUNT
['PROPERTY_HS_MEETING_OUTCOME', 'MEETING_OUTCOME', 'PROPERTY_HS_MEETING_CHANGE_ID', 'MEETING_CHANGE_ID']
PROPERTY_HS_OBJECT_SOURCE
['PROPERTY_HS_MEETING_OUTCOME', 'MEETING_OUTCOME', 'PROPERTY_HS_MEETING_CHANGE_ID', 'MEETING_CHANGE_ID']
PROPERTY_HS_CONTACT_FIRST_OUTREACH_DATE
['PROPERTY_HS_MEETING_OUTCOME', 'MEETING_OUTCOME', 'PROPERTY_HS_MEETING_CHANGE_ID', 'MEETING_CHANGE_ID']
PROPERTY_HS_UNIQUE_ID
['PROPERTY_HS_MEETING_OUTCOME', 'MEETING_OUTCOME', 'PROPERTY_HS_MEETING_CHANGE_ID', 'MEETING_CHANGE_ID']
PROPERTY_HS_BODY_PREVIEW_HTML
['PROPERTY_HS_MEETING_OUTCOME', 'MEETING_OUTCOME', 'PROPERTY_HS_MEETING_CHANGE_ID', 'MEETING_CHANGE_ID']
PROPERTY_HS_MEETING_END_TIME
['PROPERTY_HS_MEETING_OUTCOME', 'MEETING_OUTCOME', 'PROPERTY_HS_MEETING_CHANGE_ID', 'MEETING_CHANGE_ID']
PROPERTY_HS_MEETING_SOURCE
['PROPERTY_HS_MEETING_OUTCOME', 'MEETING_OUTCOME', 'PROPERTY_HS_MEETING_CHANGE_ID', 'MEETING_CHANGE_ID']
PROPERTY_HS_USER_IDS_OF_ALL_OWNERS
['PROPERTY_HS_MEETING_OUTCOME', 'MEETING_OUTCOME', 'PROPERTY_HS_MEETING_CHANGE_ID', 'MEETING_CHANGE_ID']
PROPERTY_HS_MODIFIED_BY
['PROPERTY_HS_MEETING_OUTCOME', 'MEETING_OUTCOME', 'PROPERTY_HS_MEETING_CHANGE_ID', 'MEETING_CHANGE_ID', 'PROPERTY_HS_INTERNAL_MEETING_NOTES', 'INTERNAL_MEETING_NOTES']
PROPERTY_HS_MEETING_EXTERNAL_URL
['PROPERTY_HS_MEETING_OUTCOME', 'MEETING_OUTCOME', 'PROPERTY_HS_MEETING_CHANGE_ID', 'MEETING_CHANGE_ID', 'PROPERTY_HS_INTERNAL_MEETING_NOTES', 'INTERNAL_MEETING_NOTES']
PROPERTY_HS_ALL_ACCESSIBLE_TEAM_IDS
['PROPERTY_HS_MEETING_OUTCOME', 'MEETING_OUTCOME', 'PROPERTY_HS_MEETING_CHANGE_ID', 'MEETING_CHANGE_ID', 'PROPERTY_HS_INTERNAL_MEETING_NOTES', 'INTERNAL_MEETING_NOTES']
PROPERTY_HS_MEETING_LOCATION
['PROPERTY_HS_MEETING_OUTCOME', 'MEETING_OUTCOME', 'PROPERTY_HS_MEETING_CHANGE_ID', 'MEETING_CHANGE_ID', 'PROPERTY_HS_INTERNAL_MEETING_NOTES', 'INTERNAL_MEETING_NOTES']
PROPERTY_HS_BODY_PREVIEW_IS_TRUNCATED
['PROPERTY_HS_MEETING_OUTCOME', 'MEETING_OUTCOME', 'PROPERTY_HS_MEETING_CHANGE_ID', 'MEETING_CHANGE_ID', 'PROPERTY_HS_INTERNAL_MEETING_NOTES', 'INTERNAL_MEETING_NOTES']
PROPERTY_HS_OUTCOME_CANCELED_COUNT
['PROPERTY_HS_MEETING_OUTCOME', 'MEETING_OUTCOME', 'PROPERTY_HS_MEETING_CHANGE_ID', 'MEETING_CHANGE_ID', 'PROPERTY_HS_INTERNAL_MEETING_NOTES', 'INTERNAL_MEETING_NOTES']
PROPERTY_HS_MEETING_TITLE
['PROPERTY_HS_MEETING_OUTCOME', 'MEETING_OUTCOME', 'PROPERTY_HS_MEETING_CHANGE_ID', 'MEETING_CHANGE_ID', 'PROPERTY_HS_INTERNAL_MEETING_NOTES', 'INTERNAL_MEETING_NOTES']
PROPERTY_HS_MEETING_SOURCE_ID
['PROPERTY_HS_MEETING_OUTCOME', 'MEETING_OUTCOME', 'PROPERTY_HS_MEETING_CHANGE_ID', 'MEETING_CHANGE_ID', 'PROPERTY_HS_INTERNAL_MEETING_NOTES', 'INTERNAL_MEETING_NOTES']
PROPERTY_HS_MEETING_CREATED_FROM_LINK_ID
['PROPERTY_HS_MEETING_OUTCOME', 'MEETING_OUTCOME', 'PROPERTY_HS_MEETING_CHANGE_ID', 'MEETING_CHANGE_ID', 'PROPERTY_HS_INTERNAL_MEETING_NOTES', 'INTERNAL_MEETING_NOTES', 'PROPERTY_HS_ATTENDEE_OWNER_IDS', 'ATTENDEE_OWNER_IDS']
PROPERTY_HS_UPDATED_BY_USER_ID
['PROPERTY_HS_MEETING_OUTCOME', 'MEETING_OUTCOME', 'PROPERTY_HS_MEETING_CHANGE_ID', 'MEETING_CHANGE_ID', 'PROPERTY_HS_INTERNAL_MEETING_NOTES', 'INTERNAL_MEETING_NOTES', 'PROPERTY_HS_ATTENDEE_OWNER_IDS', 'ATTENDEE_OWNER_IDS']
PROPERTY_HS_CREATED_BY_USER_ID
['PROPERTY_HS_MEETING_OUTCOME', 'MEETING_OUTCOME', 'PROPERTY_HS_MEETING_CHANGE_ID', 'MEETING_CHANGE_ID', 'PROPERTY_HS_INTERNAL_MEETING_NOTES', 'INTERNAL_MEETING_NOTES', 'PROPERTY_HS_ATTENDEE_OWNER_IDS', 'ATTENDEE_OWNER_IDS']
PROPERTY_HS_ENGAGEMENT_SOURCE
['PROPERTY_HS_MEETING_OUTCOME', 'MEETING_OUTCOME', 'PROPERTY_HS_MEETING_CHANGE_ID', 'MEETING_CHANGE_ID', 'PROPERTY_HS_INTERNAL_MEETING_NOTES', 'INTERNAL_MEETING_NOTES', 'PROPERTY_HS_ATTENDEE_OWNER_IDS', 'ATTENDEE_OWNER_IDS']
PROPERTY_HS_MEETING_BODY
['PROPERTY_HS_MEETING_OUTCOME', 'MEETING_OUTCOME', 'PROPERTY_HS_MEETING_CHANGE_ID', 'MEETING_CHANGE_ID', 'PROPERTY_HS_INTERNAL_MEETING_NOTES', 'INTERNAL_MEETING_NOTES', 'PROPERTY_HS_ATTENDEE_OWNER_IDS', 'ATTENDEE_OWNER_IDS']
PROPERTY_HS_BODY_PREVIEW
['PROPERTY_HS_MEETING_OUTCOME', 'MEETING_OUTCOME', 'PROPERTY_HS_MEETING_CHANGE_ID', 'MEETING_CHANGE_ID', 'PROPERTY_HS_INTERNAL_MEETING_NOTES', 'INTERNAL_MEETING_NOTES', 'PROPERTY_HS_ATTENDEE_OWNER_IDS', 'ATTENDEE_OWNER_IDS']
PROPERTY_HS_OUTCOME_RESCHEDULED_COUNT
['PROPERTY_HS_MEETING_OUTCOME', 'MEETING_OUTCOME', 'PROPERTY_HS_MEETING_CHANGE_ID', 'MEETING_CHANGE_ID', 'PROPERTY_HS_INTERNAL_MEETING_NOTES', 'INTERNAL_MEETING_NOTES', 'PROPERTY_HS_ATTENDEE_OWNER_IDS', 'ATTENDEE_OWNER_IDS']
PROPERTY_HUBSPOT_OWNER_ASSIGNEDDATE
['PROPERTY_HS_MEETING_OUTCOME', 'MEETING_OUTCOME', 'PROPERTY_HS_MEETING_CHANGE_ID', 'MEETING_CHANGE_ID', 'PROPERTY_HS_INTERNAL_MEETING_NOTES', 'INTERNAL_MEETING_NOTES', 'PROPERTY_HS_ATTENDEE_OWNER_IDS', 'ATTENDEE_OWNER_IDS']
PROPERTY_HS_GDPR_DELETED
['PROPERTY_HS_MEETING_OUTCOME', 'MEETING_OUTCOME', 'PROPERTY_HS_MEETING_CHANGE_ID', 'MEETING_CHANGE_ID', 'PROPERTY_HS_INTERNAL_MEETING_NOTES', 'INTERNAL_MEETING_NOTES', 'PROPERTY_HS_ATTENDEE_OWNER_IDS', 'ATTENDEE_OWNER_IDS']
PROPERTY_HS_MEETING_CALENDAR_EVENT_HASH
['PROPERTY_HS_MEETING_OUTCOME', 'MEETING_OUTCOME', 'PROPERTY_HS_MEETING_CHANGE_ID', 'MEETING_CHANGE_ID', 'PROPERTY_HS_INTERNAL_MEETING_NOTES', 'INTERNAL_MEETING_NOTES', 'PROPERTY_HS_ATTENDEE_OWNER_IDS', 'ATTENDEE_OWNER_IDS']
PROPERTY_HS_TIME_TO_BOOK_MEETING_FROM_FIRST_CONTACT
['PROPERTY_HS_MEETING_OUTCOME', 'MEETING_OUTCOME', 'PROPERTY_HS_MEETING_CHANGE_ID', 'MEETING_CHANGE_ID', 'PROPERTY_HS_INTERNAL_MEETING_NOTES', 'INTERNAL_MEETING_NOTES', 'PROPERTY_HS_ATTENDEE_OWNER_IDS', 'ATTENDEE_OWNER_IDS']
PROPERTY_HS_AT_MENTIONED_OWNER_IDS
['PROPERTY_HS_MEETING_OUTCOME', 'MEETING_OUTCOME', 'PROPERTY_HS_MEETING_CHANGE_ID', 'MEETING_CHANGE_ID', 'PROPERTY_HS_INTERNAL_MEETING_NOTES', 'INTERNAL_MEETING_NOTES', 'PROPERTY_HS_ATTENDEE_OWNER_IDS', 'ATTENDEE_OWNER_IDS']
PROPERTY_HS_OBJECT_SOURCE_ID
['PROPERTY_HS_MEETING_OUTCOME', 'MEETING_OUTCOME', 'PROPERTY_HS_MEETING_CHANGE_ID', 'MEETING_CHANGE_ID', 'PROPERTY_HS_INTERNAL_MEETING_NOTES', 'INTERNAL_MEETING_NOTES', 'PROPERTY_HS_ATTENDEE_OWNER_IDS', 'ATTENDEE_OWNER_IDS']
PROPERTY_HS_ALL_TEAM_IDS
['PROPERTY_HS_MEETING_OUTCOME', 'MEETING_OUTCOME', 'PROPERTY_HS_MEETING_CHANGE_ID', 'MEETING_CHANGE_ID', 'PROPERTY_HS_INTERNAL_MEETING_NOTES', 'INTERNAL_MEETING_NOTES', 'PROPERTY_HS_ATTENDEE_OWNER_IDS', 'ATTENDEE_OWNER_IDS']
PROPERTY_HS_CREATED_BY
['PROPERTY_HS_MEETING_OUTCOME', 'MEETING_OUTCOME', 'PROPERTY_HS_MEETING_CHANGE_ID', 'MEETING_CHANGE_ID', 'PROPERTY_HS_INTERNAL_MEETING_NOTES', 'INTERNAL_MEETING_NOTES', 'PROPERTY_HS_ATTENDEE_OWNER_IDS', 'ATTENDEE_OWNER_IDS']
PROPERTY_HS_OBJECT_ID
['PROPERTY_HS_MEETING_OUTCOME', 'MEETING_OUTCOME', 'PROPERTY_HS_MEETING_CHANGE_ID', 'MEETING_CHANGE_ID', 'PROPERTY_HS_INTERNAL_MEETING_NOTES', 'INTERNAL_MEETING_NOTES', 'PROPERTY_HS_ATTENDEE_OWNER_IDS', 'ATTENDEE_OWNER_IDS']
PROPERTY_HS_ALL_OWNER_IDS
['PROPERTY_HS_MEETING_OUTCOME', 'MEETING_OUTCOME', 'PROPERTY_HS_MEETING_CHANGE_ID', 'MEETING_CHANGE_ID', 'PROPERTY_HS_INTERNAL_MEETING_NOTES', 'INTERNAL_MEETING_NOTES', 'PROPERTY_HS_ATTENDEE_OWNER_IDS', 'ATTENDEE_OWNER_IDS']
```